### PR TITLE
Update get_document_model call

### DIFF
--- a/wagtail_storages/factories.py
+++ b/wagtail_storages/factories.py
@@ -1,5 +1,5 @@
 from wagtail.core.models import Collection, CollectionViewRestriction
-from wagtail.documents.models import get_document_model
+from wagtail.documents import get_document_model
 
 import factory
 import factory.django

--- a/wagtail_storages/signal_handlers.py
+++ b/wagtail_storages/signal_handlers.py
@@ -4,7 +4,7 @@ import logging
 from django.db.models.signals import post_save, pre_delete
 
 from wagtail.core.models import Collection
-from wagtail.documents.models import get_document_model
+from wagtail.documents import get_document_model
 
 from wagtail_storages.utils import (
     is_s3_boto3_storage_used,

--- a/wagtail_storages/utils.py
+++ b/wagtail_storages/utils.py
@@ -5,7 +5,7 @@ from django.core.files.storage import get_storage_class
 
 from wagtail.contrib.frontend_cache.utils import PurgeBatch
 from wagtail.core.models import Site
-from wagtail.documents.models import get_document_model
+from wagtail.documents import get_document_model
 
 import storages.backends.s3boto3
 


### PR DESCRIPTION
A quick fix to the get_document_model warning on the project with wagtail 2.9

You might not want to merge this right away for backwards compatibily, I have not tested this on versions <2.9