### PR TITLE
Update classifiers to include wagtail 3.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Framework :: Django :: 3.2
     Framework :: Django :: 4
     Framework :: Wagtail :: 2
+    Framework :: Wagtail :: 3
 keywords =
     wagtail
     s3


### PR DESCRIPTION
Currently, the classifiers do not state that this package supports Wagtail ==3.0, which is reflected on PyPi.  https://pypi.org/project/wagtail-storages/