### PR TITLE
Add support for Wagtail 4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+Unreleased
+----------
+* Support Wagtail 4
+
 0.5.1rc1 - 30th May 2022
 ------------------------
 * Support Wagtail 3.0.

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,9 +18,12 @@ classifiers =
     Topic :: Internet :: WWW/HTTP
     Framework :: Django
     Framework :: Django :: 3.2
-    Framework :: Django :: 4
-    Framework :: Wagtail :: 2
-    Framework :: Wagtail :: 3
+    Framework :: Django :: 4.0
+    Framework :: Django :: 4.1
+    Framework :: Wagtail :: 2.15
+    Framework :: Wagtail :: 2.16
+    Framework :: Wagtail :: 3.0
+    Framework :: Wagtail :: 4.0
 keywords =
     wagtail
     s3
@@ -31,7 +34,7 @@ keywords =
 [options]
 packages = find:
 install_requires =
-    Wagtail >=2.15,<4.0
+    Wagtail >=2.15,<5.0
     django-storages[boto3] <2
 python_requires = >=3.6
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 envlist =
-    py{37,38,39,310}-dj3-wagtail215
-    py{39,310}-dj4-wagtail216
-    py3{39,310}-dj4-wagtail{3,main}
+    py{37,38,39,310}-dj{30,31,32}-wagtail215
+    py{39,310}-dj{32,40}-wagtail216
+    py3{39,310}-dj{32,40}-wagtail{30,40}
+    py3{39,310}-dj{41}-wagtail{40,main}
     flake8
     isort
     black
@@ -12,11 +13,15 @@ setenv =
     PYTHONPATH = {toxinidir}
     DJANGO_SETTINGS_MODULE = wagtail_storages.tests.settings
 deps =
-    dj3: Django>=3,<4
-    dj4: Django>=4,<5
+    dj30: Django>=3.0,<3.1
+    dj31: Django>=3.1,<3.2
+    dj32: Django>=3.2,<4.0
+    dj40: Django>=4.0,<4.1
+    dj41: Django>=4.1,<5.0
     wagtail215: wagtail>=2.15,<2.16
     wagtail216: wagtail>=2.16,<2.17
-    wagtail3: wagtail>=3.0,<4.0
+    wagtail30: wagtail>=3.0,<4.0
+    wagtail40: wagtail>=4.0,<5.0
     wagtailmain: git+https://github.com/wagtail/wagtail.git@main#egg=Wagtail
 
 install_command = pip install -U {opts} {packages}

--- a/wagtail_storages/__init__.py
+++ b/wagtail_storages/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.5.1"
+__version__ = "0.6rc1"
 
 default_app_config = "wagtail_storages.apps.WagtailStoragesConfig"

--- a/wagtail_storages/factories.py
+++ b/wagtail_storages/factories.py
@@ -1,17 +1,14 @@
 import factory
 import factory.django
 
+from wagtail.documents import get_document_model
+
 try:
     from wagtail.models import Collection, CollectionViewRestriction
 except ImportError:
     # Wagtail<3.0
     from wagtail.core.models import Collection, CollectionViewRestriction
 
-try:
-    from wagtail.documents import get_document_model
-except ImportError:
-    # Wagtail<2.8
-    from wagtail.documents.models import get_document_model
 
 Document = get_document_model()
 

--- a/wagtail_storages/signal_handlers.py
+++ b/wagtail_storages/signal_handlers.py
@@ -3,17 +3,13 @@ import logging
 
 from django.db.models.signals import post_save, pre_delete
 
+from wagtail.documents import get_document_model
+
 try:
     from wagtail.models import Collection
 except ImportError:
     # Wagtail<3.0
     from wagtail.core.models import Collection
-
-try:
-    from wagtail.documents import get_document_model
-except ImportError:
-    # Wagtail<2.8
-    from wagtail.documents.models import get_document_model
 
 
 from wagtail_storages.utils import (

--- a/wagtail_storages/tests/settings.py
+++ b/wagtail_storages/tests/settings.py
@@ -66,3 +66,6 @@ DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
 MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
 ]
+
+if WAGTAIL_VERSION >= (3, 0):
+    WAGTAILADMIN_BASE_URL = "http://example.com"

--- a/wagtail_storages/utils.py
+++ b/wagtail_storages/utils.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.core.files.storage import get_storage_class
 
 from wagtail.contrib.frontend_cache.utils import PurgeBatch
+from wagtail.documents import get_document_model
 
 try:
     from wagtail.models import Site
@@ -11,11 +12,6 @@ except ImportError:
     # Wagtail<3.0
     from wagtail.core.models import Site
 
-try:
-    from wagtail.documents import get_document_model
-except ImportError:
-    # Wagtail<2.8
-    from wagtail.documents.models import get_document_model
 
 import storages.backends.s3boto3
 

--- a/wagtail_storages/wagtail_hooks.py
+++ b/wagtail_storages/wagtail_hooks.py
@@ -1,18 +1,13 @@
 import django
-
 import wagtail
+
+from wagtail.documents import get_document_model
 
 try:
     from wagtail.hooks import register
 except ImportError:
     # Wagtail<3.0
     from wagtail.core.hooks import register
-
-try:
-    from wagtail.documents import get_document_model
-except ImportError:
-    # Wagtail<2.8
-    from wagtail.documents.models import get_document_model
 
 from wagtail_storages import backends, utils
 


### PR DESCRIPTION
Support ticket: https://projects.torchbox.com/projects/support-team/tickets/590

This allows usage and tests for latest Wagtail and Django versions.

I also removed some code left over for Wagtail <2.8 support.