### PR TITLE
Avoid unnecessary cache purges

### DIFF
--- a/wagtail_storages/signal_handlers.py
+++ b/wagtail_storages/signal_handlers.py
@@ -46,12 +46,16 @@ def update_document_acls_when_collection_saved(sender, instance, **kwargs):
 
 @skip_if_s3_storage_not_used
 def update_document_acls_when_document_saved(sender, instance, **kwargs):
-    update_document_acl(instance)
+    update_fields = kwargs.get("update_fields")
+    if not update_fields or "collection" in update_fields or "file" in update_fields:
+        update_document_acl(instance)
 
 
 @skip_if_s3_storage_not_used
 def purge_document_from_cache_when_saved(sender, instance, **kwargs):
-    purge_document_from_cache(instance)
+    update_fields = kwargs.get("update_fields")
+    if not update_fields or "collection" in update_fields or "file" in update_fields:
+        purge_document_from_cache(instance)
 
 
 @skip_if_s3_storage_not_used


### PR DESCRIPTION
These changes update the signal handlers so that cache purges for document URLs are only triggered when the "collection" or "file" fields could have been updated (and skip them if not).

For example, if I had a background task that transcribed documents and saved the result with something like...

```
document.transcription = transcription_text
document.save(update_fields=['transcription'])
```

...the purge would be skipped.