### PR TITLE
Mention the need for public ACL support in buckets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,6 +114,9 @@ First, set up your S3 bucket. It must be configured to:
 - Allow the user to perform all the actions (``s3:*``) on the objects within the
   bucket.
 - Allow the internet traffic to access Wagtail image renditions (``images/*``).
+- Allow use of public ACLs, by disabling:
+   - "Block public access to buckets and objects granted through new access control lists (ACLs)"
+   - "Block public access to buckets and objects granted through any access control lists (ACLs)"
 
 The user permissions can be set in the IAM or via a bucket policy. See example
 of all of those points being achieved in the bucket policy below.


### PR DESCRIPTION
Otherwise, the ACLs set won't do anything.

AWS recently changed their defaults to block all bucket public access by default. This means created buckets will reject any files with a public ACL. There's nothing we need to do, but we should document explicitly that ACLs must be enabled on a bucket.