### PR TITLE
Clean-up end of life dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ classifiers =
     Development Status :: 5 - Production/Stable
     License :: OSI Approved
     License :: OSI Approved :: BSD License
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -19,10 +18,11 @@ classifiers =
     Topic :: Internet :: WWW/HTTP
     Framework :: Django
     Framework :: Django :: 3.2
-    Framework :: Django :: 4.0
     Framework :: Django :: 4.1
+    Framework :: Django :: 4.2
     Framework :: Wagtail
     Framework :: Wagtail :: 4
+    Framework :: Wagtail :: 5
 keywords =
     wagtail
     s3
@@ -35,7 +35,7 @@ packages = find:
 install_requires =
     Wagtail >=4.1
     django-storages[boto3] <2
-python_requires = >=3.6
+python_requires = >=3.8
 
 [options.packages.find]
 exclude =

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,13 @@
 [tox]
 envlist =
-    py{37}-dj{32}-wagtail{41,42,main}
-    py{38,39,310}-dj{32,40,41}-wagtail{41,42,main}
-    py{311}-dj{41}-wagtail{41,42,main}
+    py{38,39,310}-dj{32,41}-wagtail{41,42,main}
+    py{311}-dj{41,42}-wagtail{41,42,50,main}
     flake8
     isort
     black
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
@@ -21,10 +19,11 @@ setenv =
     DJANGO_SETTINGS_MODULE = wagtail_storages.tests.settings
 deps =
     dj32: Django>=3.2,<4.0
-    dj40: Django>=4.0,<4.1
-    dj41: Django>=4.1,<5.0
+    dj41: Django>=4.1,<4.2
+    dj42: Django>=4.2,<4.3
     wagtail41: wagtail>=4.1,<4.2
     wagtail42: wagtail>=4.2,<5.0
+    wagtail50: wagtail>=5.0,<6.0
     wagtailmain: git+https://github.com/wagtail/wagtail.git@main#egg=Wagtail
 
 install_command = pip install -U {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
-    py{38,39,310}-dj{32,41}-wagtail{41,42,main}
-    py{311}-dj{41,42}-wagtail{41,42,50,main}
+    py{38,39,310}-dj{32,41}-wagtail{41,42}
+    py{310,311}-dj{41}-wagtail{41}
+    py{310,311}-dj{42}-wagtail{50,main}
     flake8
     isort
     black


### PR DESCRIPTION
**This makes any changes required for Wagtail v5.0**

I found that no package code changes are required.

I made the following changes in the tox testing.

- Drop python 3.7 support (3.7 reaches end of life in June 2023)
- Drop support for Django 4.0