### PR TITLE
Wagtail 6.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+* Add tests for Wagtail 6.1 (@katdom13)
+* Drop support for Django 4.2 (@katdom13)
+
 1.1.0 - 8th March 2024
 ----------------------
 * Drop support for Wagtail < 5.2 (@katdom13)
@@ -21,7 +24,7 @@ Unreleased
 * Removed code conditionals (@katdom13)
 
 1.0.0rc1 - 11th October 2022
-----------
+----------------------------
 * Support Wagtail 4 (#33 - @nickmoreton)
 * Avoid unnecessary cache purges (#34 - @ababic)
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@ Unreleased
 ----------
 
 * Add tests for Wagtail 6.1 (@katdom13)
-* Drop support for Django 4.2 (@katdom13)
+* Drop support for Django < 4.2 (@katdom13)
 
 1.1.0 - 8th March 2024
 ----------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,10 +43,10 @@ exclude =
 
 [options.extras_require]
 testing =
-    coverage ==5.0.3
-    factory_boy ==2.12.0
-    moto ==3.1.8
-    black ==22.3.0
+    coverage ==7.5.2
+    factory_boy ==3.3.0
+    moto ==5.0.8
+    black ==24.4.2
     isort
     flake8
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Programming Language :: Python :: 3.12
     Topic :: Internet :: WWW/HTTP
     Framework :: Django
-    Framework :: Django :: 3.2
     Framework :: Django :: 4.2
     Framework :: Django :: 5.0
     Framework :: Wagtail

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 envlist =
-    py{38,39,310}-dj32-wagtail52
-    py{38,39,310,311}-dj42-wagtail{52,60}
-    py{311,312}-dj50-wagtail{52,60}
+    py{38,39,310,311}-dj42-wagtail{52,60,61}
+    py{310,311,312}-dj50-wagtail{52,60,61}
     flake8
     isort
     black
@@ -20,11 +19,11 @@ setenv =
     PYTHONPATH = {toxinidir}
     DJANGO_SETTINGS_MODULE = wagtail_storages.tests.settings
 deps =
-    dj32: Django>=3.2,<4.0
     dj42: Django>=4.2,<4.3
     dj50: Django>=5.0,<5.1
     wagtail52: wagtail>=5.2,<5.3
     wagtail60: wagtail>=6.0,<6.1
+    wagtail61: wagtail>=6.1,<6.2
     wagtailmain: git+https://github.com/wagtail/wagtail.git@main#egg=Wagtail
 
 install_command = pip install -U {opts} {packages}

--- a/wagtail_storages/tests/base.py
+++ b/wagtail_storages/tests/base.py
@@ -1,10 +1,10 @@
 from django.conf import settings
 
 import boto3
-from moto import mock_s3
+from moto import mock_aws
 
 
-@mock_s3
+@mock_aws
 class CreateBucket:
     def setUp(self):
         bucket_name = settings.AWS_STORAGE_BUCKET_NAME

--- a/wagtail_storages/tests/test_protected_documents.py
+++ b/wagtail_storages/tests/test_protected_documents.py
@@ -3,14 +3,14 @@ from urllib.parse import urlparse
 from django.test import TestCase
 from django.urls import reverse
 
-from moto import mock_s3
+from moto import mock_aws
 
 from wagtail_storages.factories import CollectionViewRestrictionFactory, DocumentFactory
 from wagtail_storages.tests.base import CreateBucket
 from wagtail_storages.tests.utils import is_s3_object_is_public
 
 
-@mock_s3
+@mock_aws
 class AmazonS3DocumentTests(CreateBucket, TestCase):
     def check_s3_url(self, url):
         return "s3.amazonaws.com" in url or "media.torchbox.com" in url

--- a/wagtail_storages/tests/test_signal_handlers.py
+++ b/wagtail_storages/tests/test_signal_handlers.py
@@ -5,7 +5,7 @@ from django.db.models.signals import post_save
 from django.test import TestCase, override_settings
 
 import factory
-from moto import mock_s3
+from moto import mock_aws
 
 from wagtail_storages.factories import (
     CollectionFactory,
@@ -39,7 +39,7 @@ class TestDecorators(TestCase):
         mock.assert_called_once()
 
 
-@mock_s3
+@mock_aws
 class TestUpdateDocumentAclsWhenCollectionSaved(CreateBucket, TestCase):
     @factory.django.mute_signals(post_save)
     def test_s3_object_acl_set_to_public(self):
@@ -60,7 +60,7 @@ class TestUpdateDocumentAclsWhenCollectionSaved(CreateBucket, TestCase):
         self.assertFalse(is_s3_object_is_public(document.file.file.obj))
 
 
-@mock_s3
+@mock_aws
 class TestUpdateDocumentAclsWhenDocumentSaved(CreateBucket, TestCase):
     @factory.django.mute_signals(post_save)
     def test_s3_object_acl_set_to_public(self):
@@ -80,7 +80,7 @@ class TestUpdateDocumentAclsWhenDocumentSaved(CreateBucket, TestCase):
         self.assertFalse(is_s3_object_is_public(document.file.file.obj))
 
 
-@mock_s3
+@mock_aws
 class TestPurgeDocumentsWhenCollectionSavedWithRestrictions(CreateBucket, TestCase):
     @override_settings(
         WAGTAILFRONTENDCACHE={
@@ -135,7 +135,7 @@ class TestPurgeDocumentsWhenCollectionSavedWithRestrictions(CreateBucket, TestCa
         urlopen_mock.assert_not_called()
 
 
-@mock_s3
+@mock_aws
 class TestPurgeDocumentFromCacheWhenSaved(CreateBucket, TestCase):
     @override_settings(
         WAGTAILFRONTENDCACHE={

--- a/wagtail_storages/tests/test_wagtail_hooks.py
+++ b/wagtail_storages/tests/test_wagtail_hooks.py
@@ -2,14 +2,14 @@ from urllib.parse import urlparse
 
 from django.test import RequestFactory, TestCase, override_settings
 
-from moto import mock_s3
+from moto import mock_aws
 
 from wagtail_storages.factories import CollectionViewRestrictionFactory, DocumentFactory
 from wagtail_storages.tests.base import CreateBucket
 from wagtail_storages.wagtail_hooks import serve_document_from_s3
 
 
-@mock_s3
+@mock_aws
 class TestWagtailHooks(CreateBucket, TestCase):
     @override_settings(
         DEFAULT_FILE_STORAGE="django.core.files.storage.FileSystemStorage"


### PR DESCRIPTION
# Notes

- No significant changes related to Wagtail 6.1

<details>
<summary>Wagtail 6.1 upgrade check list</summary>

## Code reviewing a consideration.
Use the tick box to indicate a consideration has been code reviewed as OK

### What’s new
  - [ ] [Universal listings continued](https://docs.wagtail.org/en/latest/releases/6.1.html#universal-listings-continued)
  - [ ] [Information-dense admin interface](https://docs.wagtail.org/en/latest/releases/6.1.html#information-dense-admin-interface)
  - [ ] [Custom per-page-type listings](https://docs.wagtail.org/en/latest/releases/6.1.html#custom-per-page-type-listings)
  - [ ] [Keyboard shortcuts overview](https://docs.wagtail.org/en/latest/releases/6.1.html#keyboard-shortcuts-overview)
  - [ ] [Better guidance for password-protected content](https://docs.wagtail.org/en/latest/releases/6.1.html#better-guidance-for-password-protected-content)
  - [ ] [Favicon images generation](https://docs.wagtail.org/en/latest/releases/6.1.html#favicon-images-generation)
  - [ ] [Cve-2024-32882: permission check bypass when editing a model with per-field restrictions through wagtail.contrib.settings or modelviewset](https://docs.wagtail.org/en/latest/releases/6.1.html#cve-2024-32882-permission-check-bypass-when-editing-a-model-with-per-field-restrictions-through-wagtail-contrib-settings-or-modelviewset)
  - [ ] [Other features](https://docs.wagtail.org/en/latest/releases/6.1.html#other-features)
  - [ ] [Bug fixes](https://docs.wagtail.org/en/latest/releases/6.1.html#bug-fixes)
  - [ ] [Documentation](https://docs.wagtail.org/en/latest/releases/6.1.html#documentation)
  - [ ] [Maintenance](https://docs.wagtail.org/en/latest/releases/6.1.html#maintenance)
### Changes affecting wagtail customizations
  - [ ] [Changes to submissionslistview class](https://docs.wagtail.org/en/latest/releases/6.1.html#changes-to-submissionslistview-class)
  - [ ] [Register_user_listing_buttons hook signature changed](https://docs.wagtail.org/en/latest/releases/6.1.html#register-user-listing-buttons-hook-signature-changed)
  - [ ] [Password_required_template has changed to wagtail_password_required_template](https://docs.wagtail.org/en/latest/releases/6.1.html#password-required-template-has-changed-to-wagtail-password-required-template)
  - [ ] [Document_password_required_template has changed to wagtaildocs_password_required_template](https://docs.wagtail.org/en/latest/releases/6.1.html#document-password-required-template-has-changed-to-wagtaildocs-password-required-template)
### Changes to undocumented internals
  - [ ] [Deprecation of user_listing_buttons template tag](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-user-listing-buttons-template-tag)
  - [ ] [Deprecation of wagtailusers_groups:users url pattern](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-wagtailusers-groups-users-url-pattern)
  - [ ] [Deprecation of window.chooserurls within draftail choosers](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-window-chooserurls-within-draftail-choosers)
  - [ ] [Deprecation of window.initblockwidget to initialize a streamfield block](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-window-initblockwidget-to-initialize-a-streamfield-block)
  - [ ] [Old](https://docs.wagtail.org/en/latest/releases/6.1.html#id1)
  - [ ] [New](https://docs.wagtail.org/en/latest/releases/6.1.html#id2)
  - [ ] [Removal of jquery from base client-side widget and boundwidget classes](https://docs.wagtail.org/en/latest/releases/6.1.html#removal-of-jquery-from-base-client-side-widget-and-boundwidget-classes)
  - [ ] [Window.urlify deprecated](https://docs.wagtail.org/en/latest/releases/6.1.html#window-urlify-deprecated)
  - [ ] [Window.xregexp polyfill removed](https://docs.wagtail.org/en/latest/releases/6.1.html#window-xregexp-polyfill-removed)

</details>