### PR TITLE
Deprecate Django < 4.2, Python < 3.10 and fix old mock paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.10", "3.11", "3.12"]
       fail-fast: false
 
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 
+* Drop support for Python 3.8 and 3.9 (@tm-kn)
+* Add support for Django 5.1 (@PetrDlouhy)
 * Add tests for Wagtail 6.1 (@katdom13)
 * Drop support for Django < 4.2 (@katdom13)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Framework :: Django
     Framework :: Django :: 4.2
     Framework :: Django :: 5.0
+    Framework :: Django :: 5.1
     Framework :: Wagtail
     Framework :: Wagtail :: 5
     Framework :: Wagtail :: 6
@@ -33,6 +34,7 @@ keywords =
 [options]
 packages = find:
 install_requires =
+    Django >=4.2
     Wagtail >=5.2
     django-storages[boto3] <2
 python_requires = >=3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,8 +11,6 @@ classifiers =
     Development Status :: 5 - Production/Stable
     License :: OSI Approved
     License :: OSI Approved :: BSD License
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     Django >=4.2
     Wagtail >=5.2
     django-storages[boto3] <2
-python_requires = >=3.8
+python_requires = >=3.10
 
 [options.packages.find]
 exclude =
@@ -47,7 +47,7 @@ exclude =
 testing =
     coverage ==7.5.2
     factory_boy ==3.3.0
-    moto <6
+    moto[s3] >=5,<6
     black ==24.4.2
     isort
     flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ exclude =
 testing =
     coverage ==7.5.2
     factory_boy ==3.3.0
-    moto ==5.0.8
+    moto <6
     black ==24.4.2
     isort
     flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,4 @@
 [tox]
-skipsdist = True
-usedevelop = True
 envlist =
     py{38,39,310,311}-dj42-wagtail{52,61,62}
     py{311,312}-dj{50}-wagtail{52,61,62}
@@ -18,6 +16,9 @@ python =
     3.12: py312
 
 [testenv]
+use_frozen_constraints = true
+constrain_package_deps = true
+usedevelop = True
 setenv =
     PYTHONPATH = {toxinidir}
     DJANGO_SETTINGS_MODULE = wagtail_storages.tests.settings
@@ -31,31 +32,26 @@ deps =
     wagtail62: wagtail>=6.2,<6.3
     wagtailmain: git+https://github.com/wagtail/wagtail.git@main#egg=Wagtail
 
-install_command = pip install -e ".[testing]" -U {opts} {packages}
+; install_command = pip install -U {opts} {packages}
 commands =
     coverage run --source="{toxinidir}/wagtail_storages" -m django test wagtail_storages
     django-admin check
     django-admin makemigrations --check --noinput
     coverage report -m --omit="{toxinidir}/wagtail_storages/tests/*" --fail-under=80
+extras = testing
 
 [testenv:black]
 basepython = python3
-deps =
-    black
 commands =
     black --check ./
 
 [testenv:flake8]
 basepython = python3
-deps =
-    flake8
 commands =
     flake8 wagtail_storages
 
 [testenv:isort]
 basepython = python3
-deps =
-    isort
 changedir = {toxinidir}
 commands =
     isort --check-only --diff wagtail_storages

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,6 @@
 [tox]
+skipsdist = True
+usedevelop = True
 envlist =
     py{38,39,310,311}-dj42-wagtail{52,61,62}
     py{311,312}-dj{50}-wagtail{52,61,62}
@@ -29,27 +31,31 @@ deps =
     wagtail62: wagtail>=6.2,<6.3
     wagtailmain: git+https://github.com/wagtail/wagtail.git@main#egg=Wagtail
 
-install_command = pip install -U {opts} {packages}
+install_command = pip install -e ".[testing]" -U {opts} {packages}
 commands =
     coverage run --source="{toxinidir}/wagtail_storages" -m django test wagtail_storages
     django-admin check
     django-admin makemigrations --check --noinput
     coverage report -m --omit="{toxinidir}/wagtail_storages/tests/*" --fail-under=80
-extras = testing
 
 [testenv:black]
 basepython = python3
+deps =
+    black
 commands =
     black --check ./
 
 [testenv:flake8]
 basepython = python3
+deps =
+    flake8
 commands =
     flake8 wagtail_storages
 
 [testenv:isort]
 basepython = python3
-usedevelop = false
+deps =
+    isort
 changedir = {toxinidir}
 commands =
-    isort --recursive --check-only --diff wagtail_storages
+    isort --check-only --diff wagtail_storages

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311}-dj42-wagtail{52,61,62}
+    py{310,311}-dj42-wagtail{52,61,62}
     py{311,312}-dj{50}-wagtail{52,61,62}
     py{311,312}-dj{51}-wagtail{61,62}
     flake8
@@ -9,8 +9,6 @@ envlist =
 
 [gh-actions]
 python =
-    3.8: py38
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312


### PR DESCRIPTION
A little tidy up after #50.

- A few tox.ini updates so the test dependencies are installed more consistently. There were some issues with the setup installing the wrong versions of dependencies.
- Added a broken mock for the urlopen path for the Wagtail's urlopen import.
- Deprecate Django less than 4.2 in the setup.cfg.
- Deprecate Python 3.8 and 3.9 due to issues with boto3 resolving dependencies.