### PR TITLE
Update tox testing to reflect Wagtail 6.3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{310,311}-dj42-wagtail{52,61,62}
-    py{311,312}-dj{50}-wagtail{52,61,62}
-    py{311,312}-dj{51}-wagtail{61,62}
+    py{310,311}-dj42-wagtail{52,62,63}
+    py{311,312}-dj{50}-wagtail{52,62,63}
+    py{311,312}-dj{51}-wagtail{63}
     flake8
     isort
     black
@@ -25,9 +25,8 @@ deps =
     dj50: Django>=5.0,<5.1
     dj51: Django>=5.1,<5.2
     wagtail52: wagtail>=5.2,<5.3
-    wagtail60: wagtail>=6.0,<6.1
-    wagtail61: wagtail>=6.1,<6.2
     wagtail62: wagtail>=6.2,<6.3
+    wagtail63: wagtail>=6.3,<6.4
     wagtailmain: git+https://github.com/wagtail/wagtail.git@main#egg=Wagtail
 
 commands =


### PR DESCRIPTION
This pull request updates the `tox.ini` file to modify the environment list and dependencies for compatibility with new versions of Wagtail.

Environment list updates:

* Updated the environment list to include Wagtail 6.3 and remove Wagtail 6.1.

Dependency updates:

* Removed Wagtail 6.0 and 6.1 dependencies and added Wagtail 6.3 dependency.