### PR TITLE
Wagtail 7.2 maintenance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python: ["3.10", "3.11", "3.12"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
 
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 
+* Add testing for Python 3.14 and Wagtail 7.2
 * Add testing for Wagtail 7.1 (@damwaingames)
 * Remove support for Wagtail 6.4 (@damwaingames)
 * Add tests for Wagtail 6.3, 6.4 and Python 3.13 (@ianmeigh)

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Topic :: Internet :: WWW/HTTP
     Framework :: Django
     Framework :: Django :: 4.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
-    py{310,311,312}-dj42-wagtail{63,70,71}
-    py{311,312,313}-dj{51,52}-wagtail{63,70,71}
+    py{310,311,312}-dj42-wagtail{63,70,72}
+    py{311,312,313}-dj{51,52}-wagtail{63,70,72}
+    py314-dj52-wagtail72
     flake8
     isort
     black
@@ -12,6 +13,7 @@ python =
     3.11: py311
     3.12: py312
     3.13: py313
+    3.14: py314
 
 [testenv]
 use_frozen_constraints = true
@@ -26,7 +28,7 @@ deps =
     dj52: Django>=5.2,<5.3
     wagtail63: wagtail>=6.3,<6.4
     wagtail70: wagtail>=7.0,<7.1
-    wagtail71: wagtail>=7.1,<7.2
+    wagtail72: wagtail>=7.2,<7.3
     wagtailmain: git+https://github.com/wagtail/wagtail.git@main#egg=Wagtail
 
 commands =


### PR DESCRIPTION
This pull request updates the project's testing matrix and configuration files to add support for Python 3.14 and Wagtail 7.2

**Testing and environment updates:**

* Added Python 3.14 as a supported version in `setup.cfg` classifiers and `tox.ini` environment definitions.
* Updated `tox.ini` to include Wagtail 7.2 in the test matrix and removed references to Wagtail 7.1
* Added a test environment for Python 3.14, Django 5.2, and Wagtail 7.2 in `tox.ini`.
* Documented the addition of Python 3.14 and Wagtail 7.2 testing in `CHANGELOG.rst`.