### PR TITLE
Wagtail 7.3 maintenance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python: ["3.10", "3.11", "3.12"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
 
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,8 @@
 Unreleased
 ----------
 
-* Add testing for Python 3.14 and Wagtail 7.2
+* Add testing for Python 3.14 and Wagtail 7.3
+* Drop support for Django 5.1
 * Add testing for Wagtail 7.1 (@damwaingames)
 * Remove support for Wagtail 6.4 (@damwaingames)
 * Add tests for Wagtail 6.3, 6.4 and Python 3.13 (@ianmeigh)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 
+* Add testing for Python 3.14 and Wagtail 7.2
 * Add testing for Wagtail 7.1 (@damwaingames)
 * Remove support for Wagtail 6.4 (@damwaingames)
 * Add tests for Wagtail 6.3, 6.4 and Python 3.13 (@ianmeigh)

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
     Topic :: Internet :: WWW/HTTP
     Framework :: Django
     Framework :: Django :: 4.2
-    Framework :: Django :: 5.1
     Framework :: Django :: 5.2
     Framework :: Wagtail
     Framework :: Wagtail :: 6

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Topic :: Internet :: WWW/HTTP
     Framework :: Django
     Framework :: Django :: 4.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
-    py{310,311,312}-dj42-wagtail{63,70,71}
-    py{311,312,313}-dj{51,52}-wagtail{63,70,71}
+    py{310,311,312}-dj42-wagtail{63,70,72}
+    py{311,312,313}-dj{51,52}-wagtail{63,70,72}
+    py314-dj52-wagtail72
     flake8
     isort
     black
@@ -12,6 +13,7 @@ python =
     3.11: py311
     3.12: py312
     3.13: py313
+    3.14: py314
 
 [testenv]
 use_frozen_constraints = true
@@ -26,7 +28,7 @@ deps =
     dj52: Django>=5.2,<5.3
     wagtail63: wagtail>=6.3,<6.4
     wagtail70: wagtail>=7.0,<7.1
-    wagtail71: wagtail>=7.1,<7.2
+    wagtail72: wagtail>=7.2,<7.3
     wagtailmain: git+https://github.com/wagtail/wagtail.git@main#egg=Wagtail
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{310,311,312}-dj42-wagtail{63,70,72}
-    py{311,312,313}-dj{51,52}-wagtail{63,70,72}
-    py314-dj52-wagtail72
+    py{310,311,312}-dj42-wagtail{63,70,73}
+    py{311,312,313}-dj52-wagtail{63,70,73}
+    py314-dj52-wagtail73
     flake8
     isort
     black
@@ -24,11 +24,10 @@ setenv =
     DJANGO_SETTINGS_MODULE = wagtail_storages.tests.settings
 deps =
     dj42: Django>=4.2,<4.3
-    dj51: Django>=5.1,<5.2
     dj52: Django>=5.2,<5.3
     wagtail63: wagtail>=6.3,<6.4
     wagtail70: wagtail>=7.0,<7.1
-    wagtail72: wagtail>=7.2,<7.3
+    wagtail73: wagtail>=7.3,<7.4
     wagtailmain: git+https://github.com/wagtail/wagtail.git@main#egg=Wagtail
 
 commands =


### PR DESCRIPTION
This pull request:
- Updates on top of [this PR](https://github.com/torchbox/wagtail-storages/pull/62/)
- Bumps the project's Wagtail version up to 7.3

Supported Python and Wagtail versions:
- Added support and testing for Wagtail 7.3
- Dropped support and testing for Django 5.1

Documentation:
- Updated CHANGELOG.md