### PR TITLE
Wagtail 7.4 Maintenance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,10 +62,10 @@ jobs:
           python-version: 3
 
       - name: Install dependencies
-        run: python -m pip install --upgrade setuptools wheel twine
+        run: python -m pip install --upgrade build twine
 
       - name: Build Python packages
-        run: python setup.py bdist_wheel sdist
+        run: python -m build
 
       - name: twine check
         run: twine check dist/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python: ["3.10", "3.11", "3.12"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
 
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,7 @@ Unreleased
 * Update tests to consider tasks managed by django-tasks are now deferred until
   the current transaction is committed (@ianmeigh)
 * Drop support for Wagtail < 7.0, Django < 5.2 
-* Add support for Django 6.0, Wagtail 7.4 LTS
-* Add support for Python 3.14
+* Add support for Django 6.0, Wagtail 7.4 LTS, and Python 3.14
 * Refresh development dependency pins (coverage, factory_boy, black)
 
 2.0 - 18th September 2024

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ Unreleased
 * Add tests for Wagtail 6.3, 6.4 and Python 3.13 (@ianmeigh)
 * Update tests to consider tasks managed by django-tasks are now deferred until
   the current transaction is committed (@ianmeigh)
+* Drop support for Wagtail < 7.0, Django < 5.2 
+* Add support for Django 6.0, Wagtail 7.4 LTS
+* Add support for Python 3.14
+* Refresh development dependency pins (coverage, factory_boy, black)
 
 2.0 - 18th September 2024
 -------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,13 +17,12 @@ classifiers =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Topic :: Internet :: WWW/HTTP
     Framework :: Django
-    Framework :: Django :: 4.2
-    Framework :: Django :: 5.1
     Framework :: Django :: 5.2
+    Framework :: Django :: 6.0
     Framework :: Wagtail
-    Framework :: Wagtail :: 6
     Framework :: Wagtail :: 7
 keywords =
     wagtail
@@ -35,8 +34,8 @@ keywords =
 [options]
 packages = find:
 install_requires =
-    Django >=4.2
-    Wagtail >=6.3
+    Django >=5.2
+    Wagtail >=7.0
     django-storages[boto3] <2
 python_requires = >=3.10
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,10 +45,10 @@ exclude =
 
 [options.extras_require]
 testing =
-    coverage ==7.5.2
-    factory_boy ==3.3.0
+    coverage >=7.6
+    factory_boy >=3.3
     moto[s3] >=5,<6
-    black ==24.4.2
+    black >=26.0
     isort
     flake8
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
-    py{310,311,312}-dj42-wagtail{63,70,71}
-    py{311,312,313}-dj{51,52}-wagtail{63,70,71}
+    py{310,311,312,313}-dj52-wagtail70
+    py{310,311,312,313,314}-dj52-wagtail{73,74}
+    py{312,313,314}-dj60-wagtail{73,74}
     flake8
     isort
     black
@@ -12,6 +13,7 @@ python =
     3.11: py311
     3.12: py312
     3.13: py313
+    3.14: py314
 
 [testenv]
 use_frozen_constraints = true
@@ -21,12 +23,11 @@ setenv =
     PYTHONPATH = {toxinidir}
     DJANGO_SETTINGS_MODULE = wagtail_storages.tests.settings
 deps =
-    dj42: Django>=4.2,<4.3
-    dj51: Django>=5.1,<5.2
     dj52: Django>=5.2,<5.3
-    wagtail63: wagtail>=6.3,<6.4
+    dj60: Django>=6.0,<6.1
     wagtail70: wagtail>=7.0,<7.1
-    wagtail71: wagtail>=7.1,<7.2
+    wagtail73: wagtail>=7.3,<7.4
+    wagtail74: wagtail>=7.4,<7.5
     wagtailmain: git+https://github.com/wagtail/wagtail.git@main#egg=Wagtail
 
 commands =


### PR DESCRIPTION
## Summary

Aligns supported Python, Django, and Wagtail versions with the official support matrices as of 2026-05-26.

- **Wagtail**: drop 6.3 LTS (EOL 2026-05-01) and 7.1 (EOL); target Wagtail 7.0 LTS, 7.3, and 7.4 LTS.
- **Django**: drop 4.2 and 5.1 (both EOL); target Django 5.2 LTS and 6.0. Django 6.0 requires Python 3.12+, so the tox matrix restricts those combos accordingly.
- **Python**: add 3.14 (classifiers, tox `[gh-actions]` map, and the CI `python` matrix). Wagtail 7.0 LTS does not support Python 3.14, so that combo is excluded from the envlist.
- **Build**: replace deprecated `python setup.py bdist_wheel sdist` with `python -m build`.
- **Dev pins**: relax `coverage`, `factory_boy`, and `black` from exact pins to ranges.

No source-level changes were required — the package has no version guards or moved imports. Coverage remains at 100% across the representative tox envs run locally.

Commits are split per the package modernisation policy:
1. Production: classifiers, `install_requires`, `tox.ini`, CI Python matrix, `CHANGELOG.rst`.
2. Dev tooling: `testing` extras and build step.

Sources (retrieved 2026-05-26):
- https://devguide.python.org/versions/
- https://www.djangoproject.com/download/
- https://github.com/wagtail/wagtail/wiki/Release-schedule
- https://docs.wagtail.org/en/stable/releases/upgrading.html#compatible-django-python-versions

## Test plan

- [x] `tox -l` resolves the envlist cleanly
- [x] `tox -e py312-dj52-wagtail70` passes (Wagtail 7.0 LTS)
- [x] `tox -e py312-dj52-wagtail74` passes (Wagtail 7.4 LTS)
- [x] `tox -e py312-dj60-wagtail74` passes (Django 6.0 + Wagtail 7.4 LTS)
- [x] `tox -e black,flake8,isort` pass
- [ ] GitHub Actions matrix run is green across Python 3.10–3.14
- [ ] `python -m build` job uploads sdist + wheel and `twine check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)